### PR TITLE
add new3ds flag, don't automatically enable some flags if -f is used

### DIFF
--- a/source/3ds/smdh.h
+++ b/source/3ds/smdh.h
@@ -54,7 +54,8 @@ typedef enum {
     RATING_REQUIED = 0x0040,
     USE_SAVE_DATA = 0x0080,
     RECORD_USAGE = 0x0100,
-    DISABLE_SAVE_BACKUPS = 0x0400
+    DISABLE_SAVE_BACKUPS = 0x0400,
+    NEW_3DS = 0x1000
 } SMDHFlag;
 
 typedef struct {
@@ -67,7 +68,7 @@ typedef struct {
     u8 gameRatings[0x10] = {0};
     u32 regionLock = REGION_FREE;
     u8 matchMakerId[0xC] = {0};
-    u32 flags = VISIBLE | ALLOW_3D | RECORD_USAGE;
+    u32 flags = 0;
     u16 eulaVersion = 0;
     u16 reserved1 = 0;
     u32 optimalBannerFrame = 0;

--- a/source/cmd.cpp
+++ b/source/cmd.cpp
@@ -356,7 +356,7 @@ void cmd_print_info(const std::string& command) {
         printf("  -r/--regions: Optional. Comma separated list of regions to lock the SMDH to.\n");
         printf("     Valid regions: regionfree, japan, northamerica, europe, australia, china, korea, taiwan.\n");
         printf("  -f/--flags: Optional. Flags to apply to the SMDH file.\n");
-        printf("     Valid flags: visible, autoboot, allow3d, requireeula, autosave, extendedbanner, ratingrequired, savedata, recordusage, nosavebackups.\n");
+        printf("     Valid flags: visible, autoboot, allow3d, requireeula, autosave, extendedbanner, ratingrequired, savedata, recordusage, nosavebackups, new3ds.\n");
         printf("  -mmid/--matchmakerid: Optional. Match maker ID of the SMDH.\n");
         printf("  -ev/--eulaversion: Optional. Version of the EULA required to be accepted before launching.\n");
         printf("  -obf/--optimalbannerframe: Optional. Optimal frame of the accompanying banner.\n");
@@ -490,6 +490,8 @@ int cmd_process_command(int argc, char* argv[]) {
                 smdh.settings.flags |= RECORD_USAGE;
             } else if(flag.compare("nosavebackups") == 0) {
                 smdh.settings.flags |= DISABLE_SAVE_BACKUPS;
+            } else if(flag.compare("new3ds") == 0) {
+                smdh.settings.flags |= NEW_3DS;
             } else {
                 cmd_invalid_arg("flags", command);
             }


### PR DESCRIPTION
* adds a [`new3ds` flag](https://3dbrew.org/w/index.php?title=SMDH&diff=17938&oldid=17571) to be used with `-f`. this enables [this error](http://i.imgur.com/RJz8X4S.jpg) if you try to open the title on Old 3DS.
* stops `visible,allow3d,recordusage` from automatically being enabled if `-f` is used and aren't directly specified. if `-f` isn't used, they're still enabled by default.