### PR TITLE
malloc.h is linux specific and should NOT be used.

### DIFF
--- a/source/3ds/lz11.cpp
+++ b/source/3ds/lz11.cpp
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <sstream>
 

--- a/source/pc/stb_vorbis.c
+++ b/source/pc/stb_vorbis.c
@@ -551,7 +551,7 @@ enum STBVorbisError
 #include <assert.h>
 #include <math.h>
 #if !(defined(__APPLE__) || defined(MACOSX) || defined(macintosh) || defined(Macintosh))
-#include <malloc.h>
+#include <stdlib.h>
 #endif
 #else // STB_VORBIS_NO_CRT
 #define NULL 0


### PR DESCRIPTION
malloc.h is deprecated and should be replaced with stdlib.h. This also makes the build under freebsd possible again, which removed malloc.h completely.

Also one of the other files missed including stdlib.h or malloc.h completely which also lead to a compilation error under freebsd.